### PR TITLE
add references related to ROF model

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -5557,3 +5557,117 @@
 	title = {{$\epsilon$-entropy and $\epsilon$-capacity of sets in function spaces}},
 	volume = 14,
 	year = 1959}
+
+@article{almansa2008tv,
+	title = {A {{TV}} Based Restoration Model with Local Constraints},
+	author = {Almansa, A. and Ballester, C. and Caselles, V. and Haro, G.},
+	year = {2008},
+	month = mar,
+	journal = {Journal of Scientific Computing},
+	volume = {34},
+	number = {3},
+	pages = {209--236}}
+
+@article{candes2002new,
+	title = {New Multiscale Transforms, Minimum Total Variation Synthesis: {{Applications}} to Edge-Preserving Image Reconstruction},
+	shorttitle = {New Multiscale Transforms, Minimum Total Variation Synthesis},
+	author = {Cand{\`e}s, Emmanuel J. and Guo, Franck},
+	year = {2002},
+	month = nov,
+	journal = {Signal Processing},
+	volume = {82},
+	number = {11},
+	pages = {1519--1543}}
+
+@article{chambolle2004algorithm,
+	title = {An Algorithm for Total Variation Minimization and Applications},
+	author = {Chambolle, Antonin},
+	year = {2004},
+	month = jan,
+	journal = {Journal of Mathematical Imaging and Vision},
+	volume = {20},
+	number = {1},
+	pages = {89--97},
+	publisher = {{Kluwer Academic Publishers}}}
+
+@incollection{chambolle2005total,
+	title = {Total Variation Minimization and a Class of Binary {{MRF}} Models},
+	booktitle = {Energy {{Minimization Methods}} in {{Computer Vision}} and {{Pattern Recognition}}},
+	author = {Chambolle, Antonin},
+	editor = {Hutchison, David and Kanade, Takeo and Kittler, Josef and Kleinberg, Jon M. and Mattern, Friedemann and Mitchell, John C. and Naor, Moni and Nierstrasz, Oscar and Pandu Rangan, C. and Steffen, Bernhard and Sudan, Madhu and Terzopoulos, Demetri and Tygar, Dough and Vardi, Moshe Y. and Weikum, Gerhard and Rangarajan, Anand and Vemuri, Baba and Yuille, Alan L.},
+	year = {2005},
+	volume = {3757},
+	pages = {136--152},
+	publisher = {{Springer Berlin Heidelberg}},
+	address = {{Berlin, Heidelberg}}}
+
+@article{chan2000highorder,
+	title = {High-Order Total Variation-Based Image Restoration},
+	author = {Chan, Tony and Marquina, Antonio and Mulet, Pep},
+	year = {2000},
+	month = jan,
+	journal = {SIAM Journal on Scientific Computing},
+	volume = {22},
+	number = {2},
+	pages = {503--516}}
+
+@article{chan2005aspects,
+	title = {Aspects of Total Variation Regularized {{{\emph{L}}}} {\textsuperscript{1}} Function Approximation},
+	author = {Chan, Tony F. and Esedoglu, Selim},
+	year = {2005},
+	month = jan,
+	journal = {SIAM Journal on Applied Mathematics},
+	volume = {65},
+	number = {5},
+	pages = {1817--1837}}
+
+@article{dong2011automated,
+	title = {Automated Regularization Parameter Selection in Multi-Scale Total Variation Models for Image Restoration},
+	author = {Dong, Yiqiu and Hinterm{\"u}ller, Michael and {Rincon-Camacho}, M. Monserrat},
+	year = {2011},
+	month = may,
+	journal = {Journal of Mathematical Imaging and Vision},
+	volume = {40},
+	number = {1},
+	pages = {82--104}}
+
+@article{nikolova2002minimizers,
+	title = {Minimizers of Cost-Functions Involving Nonsmooth Data-Fidelity Terms. {{Application}} to the Processing of Outliers},
+	author = {Nikolova, Mila},
+	year = {2002},
+	month = jan,
+	journal = {SIAM Journal on Numerical Analysis},
+	volume = {40},
+	number = {3},
+	pages = {965--994}}
+
+@article{nikolova2004variational,
+	title = {A Variational Approach to Remove Outliers and Impulse Noise},
+	author = {Nikolova, Mila},
+	year = {2004},
+	month = jan,
+	journal = {Journal of Mathematical Imaging and Vision},
+	volume = {20},
+	number = {1/2},
+	pages = {99--120}}
+
+@article{nikolova2004weakly,
+	title = {Weakly Constrained Minimization: {{Application}} to the Estimation of Images and Signals Involving Constant Regions},
+	shorttitle = {Weakly Constrained Minimization},
+	author = {Nikolova, Mila},
+	year = {2004},
+	month = sep,
+	journal = {Journal of Mathematical Imaging and Vision},
+	volume = {21},
+	number = {2},
+	pages = {155--175}}
+
+@inproceedings{rudin1994total,
+	title = {Total Variation Based Image Restoration with Free Local Constraints},
+	booktitle = {Proceedings of 1st {{International Conference}} on {{Image Processing}}},
+	author = {Rudin, L.I. and Osher, S.},
+	year = {1994},
+	volume = {1},
+	pages = {31--35},
+	publisher = {{IEEE Comput. Soc. Press}},
+	address = {{Austin, TX, USA}}}


### PR DESCRIPTION
`rudin1992nonlinear`

* Introduced the ROF functional for denoising images, i.e., minimize the total variation of the image estimate subject to constraints on the residuals (mean zero with variance \sigma^2).  
* The latter constraint, when relaxed from an equality to an inequality, can be in terms of L^2 data fidelity 

`rudin1994total`

* Follow up to 1992 paper proposing the ROF functional.  Reviews variations of the ROF functional and proposes TV-based extensions.

`vogel1996iterative`

* Considers the "penalized/Lagrangian form" of the ROF functional, which looks like TV-penalized nonparametric regression.  Gives methods for solving.

`chambolle1997image`

* Shows existence and uniqueness of the solution to the ROF functional.
* Shows that the original ROF functional, which had an || u - u_0 ||_2^2 = \sigma^2 _equality_ constraint, is equivalent to the problem where the equality is replaced by an inequality (making the problem convex).  Gives a problem to solve this relaxed problem.
* Proposes extensions using a kind of anisotropic total variation, as well as decomposing u to separately impose first- and second-order total variation penalties.
* Shows equivalence between the original ROF functional and the Lagrangian form.

`chan2000highorder`

* Proposes another higher-order extension to the ROF model (specifically a nonlinear fourth order diffusion equation).
* Motivation: allow jumps without subjecting smooth regions to "staircasing".

`candes2002new` ("New multiscale transforms, minimum total variation synthesis...")

* Retains the TV minimization of the ROF functional, but replaces the $L^2$ distance to observation constraint with a distance based on the coefficients of a multiscale transform (e.g., ridgelets, curvelets).

`chambolle2004algorithm`

* Gives an iterative algorithm for minimizing the TV of an image subject to some constraints, including image denoising.
* Unlike the usual ROF model literature, here assumes a discrete model.  The discrete TV here is the sum of $\ell_2$ norms of "discrete gradients" (approximation to gradient using first differences).  This can be thought to be closer to isotropic than the usual discrete TV in TV denoising (which is the sum of $\ell_1$ norms of "discrete gradients").

`chambolle2005total`

* The discrete model is studied, with "anisotropic" discrete total variation.  So this is the usual "TV denoising on the grid"
* Establishes an equivalence between TV denoising and a class of binary Markov random field models.

`chan2005aspects`

* Takes the penalized form of the ROF model, and replaces the L^2 data fidelity term with an L^1 data fidelity term (continuum setting).
* Some references cited within related to using the L^1 data fidelity term,  but not using continuum model - may actually be close to "quantile regression with TV regularization" but from the image processing community?  `nikolova2002minimizers`, `nikolova2004variational`, `nikolova2004weakly`

`dong2011automated`

* Takes the ROF model, replaces the L^2 data fidelity term with a multiscale data fidelity term, i.e., the integration is against $\lambda(x)$ which weights different parts of the domain.  Studies the continuum model.
* Closely related: `almansa2008tv`: Like `dong2011automated`, but studying the discretized model.