### PR TITLE
tv reg papers from multiscale estimation

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -5784,3 +5784,32 @@
 	volume = {38},
 	number = {1},
 	pages = {152--158}}
+
+@article{delalamo2020total,
+	title = {Total Variation Multiscale Estimators for Linear Inverse Problems},
+	author = {{del {\'A}lamo}, Miguel and Munk, Axel},
+	year = {2020},
+	month = dec,
+	journal = {Information and Inference: A Journal of the IMA},
+	volume = {9},
+	number = {4},
+	pages = {961--986}}
+
+@article{delalamo2021frameconstrained,
+	title = {Frame-Constrained Total Variation Regularization for White Noise Regression},
+	author = {{del {\'A}lamo}, Miguel and Li, Housen and Munk, Axel},
+	year = {2021},
+	month = jun,
+	journal = {The Annals of Statistics},
+	volume = {49},
+	number = {3}}
+
+@article{donoho1995nonlinear,
+	title = {Nonlinear Solution of Linear Inverse Problems by {{Wavelet}}\textendash{{Vaguelette}} Decomposition},
+	author = {Donoho, David L.},
+	year = {1995},
+	month = apr,
+	journal = {Applied and Computational Harmonic Analysis},
+	volume = {2},
+	number = {2},
+	pages = {101--126}}


### PR DESCRIPTION
* Both papers study estimation in the Gaussian white noise model.
* `delalamo2021frameconstrained` studies denoising, and `delalamo2020total` extends to the inverse problem setting.
* For both papers, the unknown function f is assumed to lie in a BV class (no treatment of higher-order smoothness).  But, L^q rates of convergence using their estimators are derived across all d \geq 2 and q \in [1, \infty).
* Taking q=2, in the denoising setting (T = I), they obtain the n^{-1/d} corresponding to the low smoothness side of the critical boundary.
* Minimax optimality: lower bound for "high smoothness" side previously known (reference given: H\"ardle et al (2012); and they prove a lower bound for the "low smoothness" side (which is the relevant one since k=0).

Misc notes:
* (With k = 0, one needs to take q approaching 1 to preserve the "fast nonparametric rate" as d grows).
*  The linear inverse problems paper (`delalamo2020total`) may be viewed as an extension of `donoho1995nonlinear`, which treats the d=1 case.