### PR TITLE
add references for wavelets, tensor product, hyperbolic

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -5865,3 +5865,131 @@
 	title = {Nonlinear Solution of Linear Inverse Problems by {{Wavelet}}\textendash{{Vaguelette}} Decomposition},
 	volume = {2},
 	year = {1995}}
+
+@article{chui1992compactly,
+	title = {Compactly Supported Box-Spline Wavelets},
+	author = {Chui, Charles K. and St{\"o}ckler, Joachim and Ward, Joseph D.},
+	year = {1992},
+	journal = {Approximation Theory and its Applications},
+	volume = {8},
+	number = {3},
+	pages = {77--100},
+	publisher = {{Springer}}}
+
+@book{chui1992introduction,
+	title = {An Introduction to Wavelets},
+	author = {Chui, Charles K. and Lemm, Jeffrey M. and Sedigh, Sahra},
+	year = {1992},
+	month = jan,
+	publisher = {{Academic Press}},}
+
+@book{daubechies1992ten,
+	title = {Ten Lectures on Wavelets},
+	author = {Daubechies, Ingrid},
+	year = {1992},
+	series = {{{CBMS-NSF}} Regional Conference Series in Applied Mathematics},
+	number = {61},
+	publisher = {{Society for Industrial and Applied Mathematics}},
+	address = {{Philadelphia, Pa}},
+	lccn = {QA403.3 .D38 1992}}
+
+@article{devore1992wavelets,
+	title = {Wavelets},
+	author = {{DeVore}, Ronald A. and Lucier, Bradley J.},
+	year = {1992},
+	month = jan,
+	journal = {Acta Numerica},
+	volume = {1},
+	pages = {1--56}}
+
+@article{devore1998hyperbolic,
+	title = {Hyperbolic Wavelet Approximation},
+	author = {{DeVore}, Ronald A. and Konyagin, Sergei V. and Temlyakov, Vladimir N.},
+	year = {1998},
+	month = jan,
+	journal = {Constructive Approximation},
+	volume = {14},
+	number = {1},
+	pages = {1--26}}
+
+@article{lorentz1992wavelets,
+	title = {Wavelets and Generalized Box Splines},
+	author = {Lorentz, Rudolph A. H. and Madych, Wolodymyr R.},
+	year = {1992},
+	month = apr,
+	journal = {Applicable Analysis},
+	volume = {44},
+	number = {1-2},
+	pages = {51--76}}
+
+@article{mallat1989multiresolution,
+	title = {Multiresolution Approximations and Wavelet Orthonormal Bases of {{L}} 2 ({{R}})},
+	author = {Mallat, Stephane G.},
+	year = {1989},
+	month = sep,
+	journal = {Transactions of the American Mathematical Society},
+	volume = {315},
+	number = {1},
+	pages = {69}}
+
+@article{mallat1989theory,
+	title = {A Theory for Multiresolution Signal Decomposition: The Wavelet Representation},
+	shorttitle = {A Theory for Multiresolution Signal Decomposition},
+	author = {Mallat, S.G.},
+	year = {1989},
+	month = jul,
+	journal = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+	volume = {11},
+	number = {7},
+	pages = {674--693}}
+
+@book{mallat2009wavelet,
+	title = {A Wavelet Tour of Signal Processing: The Sparse Way},
+	shorttitle = {A Wavelet Tour of Signal Processing},
+	author = {Mallat, S. G.},
+	year = {2009},
+	edition = {3rd ed},
+	publisher = {{Elsevier/Academic Press}},
+	address = {{Amsterdam ; Boston}},}
+
+@article{meyer1985principe,
+	title = {Principe d'incertitude, Bases Hilbertiennes et Algebres d'operateurs},
+	author = {Meyer, Yves},
+	year = {1985},
+	journal = {S\'eminaire Bourbaki},
+	volume = {662},
+	pages = {1985--1986},
+	publisher = {{Societe Mathematique de France}}}
+
+@article{meyer1990ondelettes,
+	title = {Ondelettes et Op\'erateurs},
+	author = {Meyer, Yves},
+	year = {1990},
+	journal = {I: Ondelettes},
+	publisher = {{Hermann}}}
+
+@book{meyer1993progress,
+	title = {Progress in Wavelet Analysis and Applications},
+	shorttitle = {Progress in Wavelet Analysis and Applications},
+	author = {Meyer, Yves and Roques, Sylvie},
+	year = {1993},
+	publisher = {{Atlantica S\'eguier Fronti\`eres}},}
+
+@article{neumann1997wavelet,
+	title = {Wavelet Thresholding in Anisotropic Function Classes and Application to Adaptive Estimation of Evolutionary Spectra},
+	author = {Neumann, Michael H. and {von Sachs}, Rainer},
+	year = {1997},
+	month = feb,
+	journal = {The Annals of Statistics},
+	volume = {25},
+	number = {1}}
+
+@article{riemenschneider1992wavelets,
+	title = {Wavelets and Pre-Wavelets in Low Dimensions},
+	author = {Riemenschneider, Sherman D. and Shen, Zuowei},
+	year = {1992},
+	month = oct,
+	journal = {Journal of Approximation Theory},
+	volume = {71},
+	number = {1},
+	pages = {18--38}}


### PR DESCRIPTION
Notes on wavelets

### Background / tensor product wavelets

`mallat1989multiresolution`, `meyer1990ondelettes`, `mallat1989theory`, `meyer1985principe`

* Early papers that studied the wavelet representation of functions; often cited together with similar results (meyer is in French so I can't read it, but I'd feel bad leaving it out
* Introduced multiresolution analysis - important because given a multiresolution approximation, one may derive a wavelet such that scaling+dilation makes it an orthonormal basis for L^2(R).  This would soon inspire "multivariate" wavelet bases by considering multivariate multiresolution approximations => obtain a wavelet basis.
* Notion of tensor product wavelet (isotropic), or "separable wavelets", appear in these papers.
* `mallat1989theory` specifically credits `meyer1985principe` for studying separable wavelets.
* Given efficient computation for one-dimensional wavelet transform, tensor product wavelet (2D) can be computed easily.

`chui1992introduction, daubechies1992ten, meyer1993progress, mallat2009wavelet`

* General "canonical" references for overall wavelet background

`devore1992wavelets`

* General introduction to wavelets from appx theory point of view, but Section 3.6 has detailed discussion on multivariate wavelets.  Outlines "two options"
* Option 1: tensor product wavelets (isotropic)
* Option 2: "truly multivariate", by starting with a multiresolution approximation in several dimensions.  Specifically, take a generating function \phi which generates multiresolution subspaces, and then derive the wavelet basis for this multiresolution approximation (if you can).  "Truly multivariate" in the sense that the wavelet bases cannot be factorized ("nonseparable").  But not tensor product splines.
* Cites: `meyer1990ondelettes`, `riemenschneider1992wavelets`, `chui1992compactly`, `lorentz1992wavelets`.  Interesting: the latter three papers use box splines as the \phi that generates the multiresolution approximation from which the wavelet basis is derived.
* ^ NOT hyperbolic wavelets, but also not tensor product wavelets


### Hyperbolic wavelets

`devore1998hyperbolic`

* Begins by introducing tensor product wavelets, which are isotropic / have the same support in each coordinate direction (because tensor products only taken within each resolution level)
* Then suggests alternative approach: tensor products across (resolution level).  Studies their approximation properties.
* To my knowledge, this papers give the name "hyperbolic wavelets" - given "in analogy with the approximation by trigonometric polynomials with frequencies from the hyperbolic cross".  (cf. Temlyakov (1989) _Approximation of functions with bounded mixed derivative_. Proc. Steklov. Inst. Math., 178:1-122)

`neumann1997wavelet, neumann2000multivariate`

* Gaussian white noise model (both papers)  in the following I convert their rates using \epsilon^2 ~ 1/n
* Estimator studied: take tensor products across resolution levels to obtain a basis, apply hard/soft thresholding on the coefficients.
* 1997 paper studied an anisotropic Sobolev class with d=2 (i.e., F consisted of functions with m1 partial derivatives in Lp (in the x1 direction), m2 partial derivatives in Lp (in the x2 direction)).  Obtains rate of n^{-2\tilde m/ (2\tilde m + 2)}, where \tilde m =(1/2)(1/m_1 + 1/m_2) [Thm 2.2], with matching lower bound [Thm 2.1], using prior knowledge of m_1, m_2.  (Provides alternative estimator that doesn't use prior knowledge, but places some restrictions on the function class for which the rate holds [Thm 2.3]).
* 2000 paper extended the results to arbitrary dimension, and anistropic Besov spaces.
<img width="778" alt="Screen Shot 2021-12-22 at 04 54 46" src="https://user-images.githubusercontent.com/8422804/147112643-b8ed1d01-3b83-438c-8b26-ee93f6fe9035.png">
<img width="791" alt="Screen Shot 2021-12-22 at 05 25 54" src="https://user-images.githubusercontent.com/8422804/147112670-3e33b858-9ad5-4482-803e-762c8beb50b5.png">
* Obtains a rate of n^{-2\tilder / (2\tilde r + d)}, where \tilde r = (1/d)(1/r_1 + ... 1/r_d) [Thm 2.2], with matching lower bound [Thm 2.1].  Like before, this "cleaner" upper bound assumes prior knowledge of r_i, and Thm 2.3 removes this condition, incurring a log factor in the rate.  The following condition in Thms 2.2 and 2.3 reduces, when we take r_i = k+1 and p_i = 1 in all directions, to the requirement that 2(k+1) > d.  (There are no results for 2(k+1) < d).  With these settings, we recover the n^{-2(k+1)/(2(k+1)+d)} rate.
<img width="701" alt="Screen Shot 2021-12-22 at 06 00 37" src="https://user-images.githubusercontent.com/8422804/147113852-2bdb01c1-a148-407e-b649-7ba4c6a30707.png">
* Also offers some "bonus" results, like showing that this estimator is also optimal over an L2-Sobolev class that imposes an L2 bound on all mixed derivatives whose multi-index have _max_ degree r (not summed).  Here they obtain a "univariate nonparametric rate" of n^{-2r/(2r+1)}, with matching lower bound.  Some discussion of "strong anisotropy", where the signal is in fact univariate but in a multivariate ambient space.

I noticed that the 2000 paper is also referenced in [Lepski (2015)](https://projecteuclid.org/journals/annals-of-statistics/volume-43/issue-3/Adaptive-estimation-over-anisotropic-functional-classes-via-oracle-approach/10.1214/14-AOS1306.full), but I haven't fully parsed whether their setting is exactly the same.

<img width="660" alt="Screen Shot 2021-12-22 at 07 20 10" src="https://user-images.githubusercontent.com/8422804/147114938-f5ba1d9a-15ef-464a-808e-a98b7b9b1528.png">



