### PR TITLE
remove incorrect (and incomplete, with nonstandard bibkey) entry

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -4431,12 +4431,6 @@
 	title = {A Wavelet Tour of Signal Processing},
 	year = 2008}
 
-@book{wavelectures,
-	author = {Ingrid Daubechies},
-	publisher = {Society for Industrial and Applied Mathematics},
-	title = {Ten lectures in wavelets},
-	year = 1992}
-
 @article{green1985semi,
 	author = {Peter Green and Brian Yandell},
 	journal = {International Conference on Generalized Linear Models},


### PR DESCRIPTION
I noticed that the bibfile has an old entry for Daubechies's "Ten lectures on wavelets".  The entry's title is incorrect (it says "in" instead of "on", and the entry is incomplete (plus the bibkey is nonstandard). 

Since the title is incorrect, my script didn't catch the duplicate [when I added my own bibtex entry for it.](https://github.com/huisaddison/tibbles-group/blob/remove-redundant-incorrect/latex/ryantibs.bib#L5968-L5976)   Want to get rid of it?  I would have gotten rid of it myself, but I don't want to break compilation for any of your own papers that rely on the old `wavelectures` bibkey.