### PR TITLE
Cite r packages

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -6087,3 +6087,19 @@
 	primaryclass = {stat},
 	title = {Nonparametric Density Estimation by Histogram Trend Filtering},
 	year = {2016}}
+
+@manual{nason2016wavethresh,
+	title = {wavethresh: Wavelets Statistics and Transforms},
+	author = {Guy Nason},
+	year = {2016},
+	note = {R package version 4.6.8},
+	url = {https://CRAN.R-project.org/package=wavethresh}}
+
+@article{hayfield2008nonparametric,
+	title = {Nonparametric Econometrics: The np Package},
+	author = {Tristen Hayfield and Jeffrey S. Racine},
+	journal = {Journal of Statistical Software},
+	year = {2008},
+	volume = {27},
+	number = {5},
+	url = {https://www.jstatsoft.org/v27/i05/}}


### PR DESCRIPTION
Adding bibkeys to cite `wavethresh` and `np` packages in the experiments (feel free to revert if this isn't necessary/mentioning packages by name is sufficient)