### PR TITLE
Add references for Voronoi TV paper.

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -7206,3 +7206,18 @@
 	title = {Fused Density Estimation: Theory and Methods},
 	volume = {81},
 	year = {2019}}
+
+@book{gine2021mathematical,
+  title={Mathematical foundations of infinite-dimensional statistical models},
+  author={Gin{\'e}, Evarist and Nickl, Richard},
+  year={2021},
+  publisher={Cambridge University Press}}
+
+@article{cohen2003harmonic,
+  title={Harmonic analysis of the space {BV}},
+  author={Cohen, Albert and Dahmen, Wolfgang and Daubechies, Ingrid and DeVore, Ronald A.},
+  journal={Revista Matem{\'a}tica Iberoamericana},
+  volume={19},
+  number={1},
+  pages={235--263},
+  year={2003}}


### PR DESCRIPTION
Add two references -- they are cited in discussion of wavelet coefficient decay for L^\infty and BV functions (Appendix D.7.2).  