### PR TITLE
"Faterni" -> "Fatemi"

### DIFF
--- a/latex/ryantibs.bib
+++ b/latex/ryantibs.bib
@@ -6470,7 +6470,7 @@
 	year = 2010}
 
 @article{rudin1992nonlinear,
-	author = {Leonid I. Rudin and Stanley Osher and Emad Faterni},
+	author = {Leonid I. Rudin and Stanley Osher and Emad Fatemi},
 	journal = {Physica {D}: Nonlinear Phenomena},
 	number = 1,
 	pages = {259--268},


### PR DESCRIPTION
My guess is that this typo was introduced by OCR