### PR TITLE
Adjust mk-new script for compatibility with 2b355bd (Rename bib file)

### DIFF
--- a/tools/mk-new
+++ b/tools/mk-new
@@ -1,21 +1,21 @@
 if [ -z "$1" ]
-then echo "Missing input folder name"
-else 
-  mkdir $1/code
-  mkdir $1/code/fig
-  mkdir $1/notes
-  mkdir $1/paper	
-  mkdir $1/paper/fig
-  mkdir $1/paper/arxiv
-  mkdir $1/refs
-  cp ../latex/general.bib $1/notes
-  cp ../latex/macros.tex $1/notes
-  cp ../latex/template.tex $1/notes/notes.tex
-  cp ../latex/general.bib $1/paper
-  cp ../latex/macros.tex $1/paper
-  cp ../latex/template.tex $1/paper/paper.tex
-  cp cp-bib $1/notes
-  cp cp-bib $1/paper
-  cp cp-fig $1/paper
-  cp cp-arxiv $1/paper
+  then echo "Missing input folder name"
+else
+  mkdir "$1"/code
+  mkdir "$1"/code/fig
+  mkdir "$1"/notes
+  mkdir "$1"/paper
+  mkdir "$1"/paper/fig
+  mkdir "$1"/paper/arxiv
+  mkdir "$1"/refs
+  cp ../latex/main.bib "$1"/notes
+  cp ../latex/macros.tex "$1"/notes
+  cp ../latex/template.tex "$1"/notes/notes.tex
+  cp ../latex/main.bib "$1"/paper
+  cp ../latex/macros.tex "$1"/paper
+  cp ../latex/template.tex "$1"/paper/paper.tex
+  cp cp-bib "$1"/notes
+  cp cp-bib "$1"/paper
+  cp cp-fig "$1"/paper
+  cp cp-arxiv "$1"/paper
 fi


### PR DESCRIPTION
Commit 2b355bd renamed `general.bib` to `main.bib` but `mk-new` was not updated to reflect this, so it failed when I tried to initialize a new project.